### PR TITLE
Fixed new entry timer bug and added option to disable it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can further refine your search by pressing the tag icon in the top-right cor
 
 ##### Settings
 To update values remember to press `Done`/`Return`.
+You can disable the new entry timer by setting its value to 0. 
 Before exporting, you need to choose a directory.
 Importing will overwrite your current entries.
 

--- a/app/src/main/java/com/example/journal/AppUsageUtils.kt
+++ b/app/src/main/java/com/example/journal/AppUsageUtils.kt
@@ -22,7 +22,7 @@ object AppUsageUtils {
         val lastOpenedTime = sharedPreferences.getLong(LAST_OPENED_TIME, 0)
         val timerDuration = sharedPreferences.getInt(TIMER_DURATION, 300) * 1000 // default 300 seconds (5 minutes)
 
-        if (currentTime - lastOpenedTime > timerDuration) {
+        if (timerDuration != 0 && currentTime - lastOpenedTime > timerDuration) {
             createNewEntry()
         }
 

--- a/app/src/main/java/com/example/journal/SettingsActivity.kt
+++ b/app/src/main/java/com/example/journal/SettingsActivity.kt
@@ -98,9 +98,12 @@ class SettingsActivity : AppCompatActivity() {
         timerEditText.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE) {
                 val newTimerValue = timerEditText.text.toString().toIntOrNull()
-                if (newTimerValue != null && newTimerValue > 0) {
+                if (newTimerValue != null && newTimerValue > 0 && newTimerValue < 1000000) {
                     AppUsageUtils.saveTimerDuration(this, newTimerValue)
                     Toast.makeText(this, "Inactivity time updated.", Toast.LENGTH_SHORT).show()
+                } else if (newTimerValue == 0) {
+                    AppUsageUtils.saveTimerDuration(this, newTimerValue)
+                    Toast.makeText(this, "Inactivity time disabled.", Toast.LENGTH_SHORT).show()
                 } else {
                     Toast.makeText(this, "Please enter a valid time in seconds.", Toast.LENGTH_SHORT).show()
                 }


### PR DESCRIPTION
Implemented limit for new entry timer to fix issue where a high value would cause the app to always open a new entry on any action. Added option to disable it by setting the value to 0.